### PR TITLE
Run tests in a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /bin/
 composer.lock
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor/
 /bin/
 composer.lock
-.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+build:
+	docker build -t dumplie -f docker/php7/Dockerfile .
+
+test:
+	docker run --rm -it dumplie bash ./tests/run_tests.sh
+
+run:
+	docker run -it dumplie bash
+
+.PHONY: build test run

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Dumplie
+
+## Docker Environment
+
+To build the container just run: 
+
+```make build```
+
+To run tests in a previously built container: 
+
+```make test```
+
+To enter bash in a previously built container:
+
+```make run```

--- a/docker/php7/Dockerfile
+++ b/docker/php7/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:7
+
+RUN apt-get update && \
+    apt-get -y install git-core
+
+# setup workdir
+RUN mkdir /home/dumplie
+WORKDIR /home/dumplie
+
+# upload composer files
+COPY composer.json /home/dumplie
+
+# install & run composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+RUN composer install && composer clear-cache
+
+# upload the rest of the code
+COPY . /home/dumplie
+WORKDIR /home/dumplie

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./bin/phpspec run --format=pretty
+./bin/phpunit --testdox


### PR DESCRIPTION
How about adding a docker container to run all the tests?

Not everyone has php 7.0 installed on the development machine, so it is good to run tests locally, but in the container. I know ther is travis build in place, but sometimes we just want to run tests as fast as possible and continue development without pushing to the repo. 

I have also introduced Makefile to speed up the build/test/run process. 
Docker container is based on official php7 image, but this can be changed at some point in the future. 
